### PR TITLE
Add macros for generating cast implementations

### DIFF
--- a/crates/brace-cast/Cargo.toml
+++ b/crates/brace-cast/Cargo.toml
@@ -6,3 +6,7 @@ description = "A utility library for dynamic casting between trait objects."
 repository = "https://github.com/brace-rs/brace-cast"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+
+[dependencies]
+inventory = "0.1"
+lazy_static = "1.4"

--- a/crates/brace-cast/src/lib.rs
+++ b/crates/brace-cast/src/lib.rs
@@ -196,33 +196,9 @@ mod tests {
 
     impl_cast_as!(struct Cat: Animal, Feline);
 
-    impl CastAsRef<Cat> for dyn Animal {
-        fn cast_as_ref(&self) -> Option<&Cat> {
-            self.cast_as_any_ref().downcast_ref()
-        }
-    }
-
-    impl CastAsMut<Cat> for dyn Animal {
-        fn cast_as_mut(&mut self) -> Option<&mut Cat> {
-            self.cast_as_any_mut().downcast_mut()
-        }
-    }
-
     impl Feline for Cat {
         fn eyes(&self) -> &usize {
             &self.eyes
-        }
-    }
-
-    impl CastAsRef<Cat> for dyn Feline {
-        fn cast_as_ref(&self) -> Option<&Cat> {
-            self.cast_as_any_ref().downcast_ref()
-        }
-    }
-
-    impl CastAsMut<Cat> for dyn Feline {
-        fn cast_as_mut(&mut self) -> Option<&mut Cat> {
-            self.cast_as_any_mut().downcast_mut()
         }
     }
 
@@ -271,33 +247,9 @@ mod tests {
 
     impl_cast_from!(struct Dog: Animal, Canine);
 
-    impl CastFromRef<dyn Animal> for Dog {
-        fn cast_from_ref<'a>(from: &'a (dyn Animal + 'static)) -> Option<&'a Self> {
-            from.cast_as_any_ref().downcast_ref()
-        }
-    }
-
-    impl CastFromMut<dyn Animal> for Dog {
-        fn cast_from_mut<'a>(from: &'a mut (dyn Animal + 'static)) -> Option<&'a mut Self> {
-            from.cast_as_any_mut().downcast_mut()
-        }
-    }
-
     impl Canine for Dog {
         fn ears(&self) -> &usize {
             &self.ears
-        }
-    }
-
-    impl CastFromRef<dyn Canine> for Dog {
-        fn cast_from_ref<'a>(from: &'a (dyn Canine + 'static)) -> Option<&'a Self> {
-            from.cast_as_any_ref().downcast_ref()
-        }
-    }
-
-    impl CastFromMut<dyn Canine> for Dog {
-        fn cast_from_mut<'a>(from: &'a mut (dyn Canine + 'static)) -> Option<&'a mut Self> {
-            from.cast_as_any_mut().downcast_mut()
         }
     }
 

--- a/crates/brace-cast/src/lib.rs
+++ b/crates/brace-cast/src/lib.rs
@@ -2,6 +2,8 @@ use std::any::Any;
 use std::rc::Rc;
 use std::sync::Arc;
 
+mod macros;
+
 pub fn cast_ref<T, U>(item: &U) -> Option<&T>
 where
     T: ?Sized,
@@ -152,7 +154,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{cast_mut, cast_ref, Cast, CastAsMut, CastAsRef, CastFromMut, CastFromRef};
+    use crate::{
+        cast_mut, cast_ref, impl_cast_as, impl_cast_from, Cast, CastAsMut, CastAsRef, CastFromMut,
+        CastFromRef,
+    };
 
     trait Animal: Cast {
         fn name(&self) -> &str;
@@ -189,17 +194,7 @@ mod tests {
         }
     }
 
-    impl CastAsRef<dyn Animal> for Cat {
-        fn cast_as_ref(&self) -> Option<&(dyn Animal + 'static)> {
-            Some(self as &dyn Animal)
-        }
-    }
-
-    impl CastAsMut<dyn Animal> for Cat {
-        fn cast_as_mut(&mut self) -> Option<&mut (dyn Animal + 'static)> {
-            Some(self as &mut dyn Animal)
-        }
-    }
+    impl_cast_as!(struct Cat: Animal, Feline);
 
     impl CastAsRef<Cat> for dyn Animal {
         fn cast_as_ref(&self) -> Option<&Cat> {
@@ -216,18 +211,6 @@ mod tests {
     impl Feline for Cat {
         fn eyes(&self) -> &usize {
             &self.eyes
-        }
-    }
-
-    impl CastAsRef<dyn Feline> for Cat {
-        fn cast_as_ref(&self) -> Option<&(dyn Feline + 'static)> {
-            Some(self as &dyn Feline)
-        }
-    }
-
-    impl CastAsMut<dyn Feline> for Cat {
-        fn cast_as_mut(&mut self) -> Option<&mut (dyn Feline + 'static)> {
-            Some(self as &mut dyn Feline)
         }
     }
 
@@ -286,17 +269,7 @@ mod tests {
         }
     }
 
-    impl CastFromRef<Dog> for dyn Animal {
-        fn cast_from_ref(from: &Dog) -> Option<&(dyn Animal + 'static)> {
-            Some(from as &dyn Animal)
-        }
-    }
-
-    impl CastFromMut<Dog> for dyn Animal {
-        fn cast_from_mut(from: &mut Dog) -> Option<&mut (dyn Animal + 'static)> {
-            Some(from as &mut dyn Animal)
-        }
-    }
+    impl_cast_from!(struct Dog: Animal, Canine);
 
     impl CastFromRef<dyn Animal> for Dog {
         fn cast_from_ref<'a>(from: &'a (dyn Animal + 'static)) -> Option<&'a Self> {
@@ -313,18 +286,6 @@ mod tests {
     impl Canine for Dog {
         fn ears(&self) -> &usize {
             &self.ears
-        }
-    }
-
-    impl CastFromRef<Dog> for dyn Canine {
-        fn cast_from_ref(from: &Dog) -> Option<&(dyn Canine + 'static)> {
-            Some(from as &dyn Canine)
-        }
-    }
-
-    impl CastFromMut<Dog> for dyn Canine {
-        fn cast_from_mut(from: &mut Dog) -> Option<&mut (dyn Canine + 'static)> {
-            Some(from as &mut dyn Canine)
         }
     }
 

--- a/crates/brace-cast/src/macros.rs
+++ b/crates/brace-cast/src/macros.rs
@@ -1,4 +1,38 @@
 #[macro_export]
+macro_rules! register_cast_ref {
+    (struct $from:path : $as:path) => {
+        $crate::inventory::submit! {
+            #![crate = $crate]
+            $crate::registry::CastRefRecord::new::<$from, dyn $as>(
+                |item| {
+                    let item: &$from = std::any::Any::downcast_ref(item)?;
+                    let item: &dyn $as = item;
+
+                    std::option::Option::Some(item)
+                }
+            )
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! register_cast_mut {
+    (struct $from:path : $as:path) => {
+        $crate::inventory::submit! {
+            #![crate = $crate]
+            $crate::registry::CastMutRecord::new::<$from, dyn $as>(
+                |item| {
+                    let item: &mut $from = std::any::Any::downcast_mut(item)?;
+                    let item: &mut dyn $as = item;
+
+                    std::option::Option::Some(item)
+                }
+            )
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! impl_cast_as {
     (struct $from:path : $as:path) => {
         $crate::impl_cast_as_ref!(struct $from : $as);
@@ -9,11 +43,23 @@ macro_rules! impl_cast_as {
         $crate::impl_cast_as_ref!(struct $from : $as $(, $also)*);
         $crate::impl_cast_as_mut!(struct $from : $as $(, $also)*);
     };
+
+    (trait $from:path : $as:path) => {
+        $crate::impl_cast_as_ref!(trait $from : $as);
+        $crate::impl_cast_as_mut!(trait $from : $as);
+    };
+
+    (trait $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_as_ref!(trait $from : $as $(, $also)*);
+        $crate::impl_cast_as_mut!(trait $from : $as $(, $also)*);
+    };
 }
 
 #[macro_export]
 macro_rules! impl_cast_as_ref {
     (struct $from:path : $as:path) => {
+        $crate::register_cast_ref!(struct $from : $as);
+
         impl $crate::CastAsRef<dyn $as> for $from
         where
             $from: $as,
@@ -39,11 +85,34 @@ macro_rules! impl_cast_as_ref {
             $crate::impl_cast_as_ref!(struct $from : $also);
         )*
     };
+
+    (trait $from:path : $as:path) => {
+        impl $crate::CastAsRef<dyn $as> for dyn $from {
+            fn cast_as_ref(&self) -> std::option::Option<&(dyn $as + 'static)> {
+                $crate::registry::cast_from_ref::<dyn $from, dyn $as>(self)
+            }
+        }
+
+        impl $crate::CastFromRef<dyn $as> for dyn $from {
+            fn cast_from_ref<'a>(from: &'a (dyn $as + 'static)) -> std::option::Option<&'a Self> {
+                $crate::registry::cast_from_ref::<dyn $as, dyn $from>(from)
+            }
+        }
+    };
+
+    (trait $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_as_ref!(trait $from : $as);
+        $(
+            $crate::impl_cast_as_ref!(trait $from : $also);
+        )*
+    };
 }
 
 #[macro_export]
 macro_rules! impl_cast_as_mut {
     (struct $from:path : $as:path) => {
+        $crate::register_cast_mut!(struct $from : $as);
+
         impl $crate::CastAsMut<dyn $as> for $from
         where
             $from: $as,
@@ -69,6 +138,27 @@ macro_rules! impl_cast_as_mut {
             $crate::impl_cast_as_mut!(struct $from : $also);
         )*
     };
+
+    (trait $from:path : $as:path) => {
+        impl $crate::CastAsMut<dyn $as> for dyn $from {
+            fn cast_as_mut(&mut self) -> std::option::Option<&mut (dyn $as + 'static)> {
+                $crate::registry::cast_from_mut::<dyn $from, dyn $as>(self)
+            }
+        }
+
+        impl $crate::CastFromMut<dyn $as> for dyn $from {
+            fn cast_from_mut<'a>(from: &'a mut (dyn $as + 'static)) -> std::option::Option<&'a mut Self> {
+                $crate::registry::cast_from_mut::<dyn $as, dyn $from>(from)
+            }
+        }
+    };
+
+    (trait $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_as_mut!(trait $from : $as);
+        $(
+            $crate::impl_cast_as_mut!(trait $from : $also);
+        )*
+    };
 }
 
 #[macro_export]
@@ -82,11 +172,23 @@ macro_rules! impl_cast_from {
         $crate::impl_cast_from_ref!(struct $from : $as $(, $also)*);
         $crate::impl_cast_from_mut!(struct $from : $as $(, $also)*);
     };
+
+    (trait $from:path : $as:path) => {
+        $crate::impl_cast_from_ref!(trait $from : $as);
+        $crate::impl_cast_from_mut!(trait $from : $as);
+    };
+
+    (trait $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_from_ref!(trait $from : $as $(, $also)*);
+        $crate::impl_cast_from_mut!(trait $from : $as $(, $also)*);
+    };
 }
 
 #[macro_export]
 macro_rules! impl_cast_from_ref {
     (struct $from:path : $as:path) => {
+        $crate::register_cast_ref!(struct $from : $as);
+
         impl $crate::CastFromRef<$from> for dyn $as
         where
             $from: $as,
@@ -112,11 +214,34 @@ macro_rules! impl_cast_from_ref {
             $crate::impl_cast_from_ref!(struct $from : $also);
         )*
     };
+
+    (trait $from:path : $as:path) => {
+        impl $crate::CastFromRef<dyn $from> for dyn $as {
+            fn cast_from_ref<'a>(from: &'a (dyn $from + 'static)) -> std::option::Option<&'a Self> {
+                $crate::registry::cast_from_ref::<dyn $from, dyn $as>(from)
+            }
+        }
+
+        impl $crate::CastAsRef<dyn $from> for dyn $as {
+            fn cast_as_ref(&self) -> std::option::Option<&(dyn $from + 'static)> {
+                $crate::registry::cast_from_ref::<dyn $as, dyn $from>(self)
+            }
+        }
+    };
+
+    (trait $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_from_ref!(trait $from : $as);
+        $(
+            $crate::impl_cast_from_ref!(trait $from : $also);
+        )*
+    };
 }
 
 #[macro_export]
 macro_rules! impl_cast_from_mut {
     (struct $from:path : $as:path) => {
+        $crate::register_cast_mut!(struct $from : $as);
+
         impl $crate::CastFromMut<$from> for dyn $as
         where
             $from: $as,
@@ -140,6 +265,27 @@ macro_rules! impl_cast_from_mut {
         $crate::impl_cast_from_mut!(struct $from : $as);
         $(
             $crate::impl_cast_from_mut!(struct $from : $also);
+        )*
+    };
+
+    (trait $from:path : $as:path) => {
+        impl $crate::CastFromMut<dyn $from> for dyn $as {
+            fn cast_from_mut<'a>(from: &'a mut (dyn $from + 'static)) -> std::option::Option<&'a mut Self> {
+                $crate::registry::cast_from_mut::<dyn $from, dyn $as>(from)
+            }
+        }
+
+        impl $crate::CastAsMut<dyn $from> for dyn $as {
+            fn cast_as_mut(&mut self) -> std::option::Option<&mut (dyn $from + 'static)> {
+                $crate::registry::cast_from_mut::<dyn $as, dyn $from>(self)
+            }
+        }
+    };
+
+    (trait $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_from_mut!(trait $from : $as);
+        $(
+            $crate::impl_cast_from_mut!(trait $from : $also);
         )*
     };
 }

--- a/crates/brace-cast/src/macros.rs
+++ b/crates/brace-cast/src/macros.rs
@@ -1,0 +1,109 @@
+#[macro_export]
+macro_rules! impl_cast_as {
+    (struct $from:path : $as:path) => {
+        $crate::impl_cast_as_ref!(struct $from : $as);
+        $crate::impl_cast_as_mut!(struct $from : $as);
+    };
+
+    (struct $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_as_ref!(struct $from : $as $(, $also)*);
+        $crate::impl_cast_as_mut!(struct $from : $as $(, $also)*);
+    };
+}
+
+#[macro_export]
+macro_rules! impl_cast_as_ref {
+    (struct $from:path : $as:path) => {
+        impl $crate::CastAsRef<dyn $as> for $from
+        where
+            $from: $as,
+        {
+            fn cast_as_ref(&self) -> std::option::Option<&(dyn $as + 'static)> {
+                std::option::Option::Some(self as &dyn $as)
+            }
+        }
+    };
+
+    (struct $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_as_ref!(struct $from : $as);
+        $(
+            $crate::impl_cast_as_ref!(struct $from : $also);
+        )*
+    };
+}
+
+#[macro_export]
+macro_rules! impl_cast_as_mut {
+    (struct $from:path : $as:path) => {
+        impl $crate::CastAsMut<dyn $as> for $from
+        where
+            $from: $as,
+        {
+            fn cast_as_mut(&mut self) -> std::option::Option<&mut (dyn $as + 'static)> {
+                std::option::Option::Some(self as &mut dyn $as)
+            }
+        }
+    };
+
+    (struct $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_as_mut!(struct $from : $as);
+        $(
+            $crate::impl_cast_as_mut!(struct $from : $also);
+        )*
+    };
+}
+
+#[macro_export]
+macro_rules! impl_cast_from {
+    (struct $from:path : $as:path) => {
+        $crate::impl_cast_from_ref!(struct $from : $as);
+        $crate::impl_cast_from_mut!(struct $from : $as);
+    };
+
+    (struct $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_from_ref!(struct $from : $as $(, $also)*);
+        $crate::impl_cast_from_mut!(struct $from : $as $(, $also)*);
+    };
+}
+
+#[macro_export]
+macro_rules! impl_cast_from_ref {
+    (struct $from:path : $as:path) => {
+        impl $crate::CastFromRef<$from> for dyn $as
+        where
+            $from: $as,
+        {
+            fn cast_from_ref(from: &$from) -> std::option::Option<&Self> {
+                std::option::Option::Some(from as &dyn $as)
+            }
+        }
+    };
+
+    (struct $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_from_ref!(struct $from : $as);
+        $(
+            $crate::impl_cast_from_ref!(struct $from : $also);
+        )*
+    };
+}
+
+#[macro_export]
+macro_rules! impl_cast_from_mut {
+    (struct $from:path : $as:path) => {
+        impl $crate::CastFromMut<$from> for dyn $as
+        where
+            $from: $as,
+        {
+            fn cast_from_mut(from: &mut $from) -> std::option::Option<&mut Self> {
+                std::option::Option::Some(from as &mut dyn $as)
+            }
+        }
+    };
+
+    (struct $from:path : $as:path $(, $also:path)+) => {
+        $crate::impl_cast_from_mut!(struct $from : $as);
+        $(
+            $crate::impl_cast_from_mut!(struct $from : $also);
+        )*
+    };
+}

--- a/crates/brace-cast/src/macros.rs
+++ b/crates/brace-cast/src/macros.rs
@@ -22,6 +22,15 @@ macro_rules! impl_cast_as_ref {
                 std::option::Option::Some(self as &dyn $as)
             }
         }
+
+        impl $crate::CastFromRef<dyn $as> for $from
+        where
+            $from: $as + $crate::Cast,
+        {
+            fn cast_from_ref<'a>(from: &'a (dyn $as + 'static)) -> std::option::Option<&'a Self> {
+                std::any::Any::downcast_ref($crate::CastAsAny::cast_as_any_ref(from))
+            }
+        }
     };
 
     (struct $from:path : $as:path $(, $also:path)+) => {
@@ -41,6 +50,15 @@ macro_rules! impl_cast_as_mut {
         {
             fn cast_as_mut(&mut self) -> std::option::Option<&mut (dyn $as + 'static)> {
                 std::option::Option::Some(self as &mut dyn $as)
+            }
+        }
+
+        impl $crate::CastFromMut<dyn $as> for $from
+        where
+            $from: $as + $crate::Cast,
+        {
+            fn cast_from_mut<'a>(from: &'a mut (dyn $as + 'static)) -> std::option::Option<&'a mut Self> {
+                std::any::Any::downcast_mut($crate::CastAsAny::cast_as_any_mut(from))
             }
         }
     };
@@ -77,6 +95,15 @@ macro_rules! impl_cast_from_ref {
                 std::option::Option::Some(from as &dyn $as)
             }
         }
+
+        impl $crate::CastAsRef<$from> for dyn $as
+        where
+            $from: $as + $crate::Cast,
+        {
+            fn cast_as_ref(&self) -> std::option::Option<&$from> {
+                std::any::Any::downcast_ref($crate::CastAsAny::cast_as_any_ref(self))
+            }
+        }
     };
 
     (struct $from:path : $as:path $(, $also:path)+) => {
@@ -96,6 +123,15 @@ macro_rules! impl_cast_from_mut {
         {
             fn cast_from_mut(from: &mut $from) -> std::option::Option<&mut Self> {
                 std::option::Option::Some(from as &mut dyn $as)
+            }
+        }
+
+        impl $crate::CastAsMut<$from> for dyn $as
+        where
+            $from: $as + $crate::Cast,
+        {
+            fn cast_as_mut(&mut self) -> std::option::Option<&mut $from> {
+                std::any::Any::downcast_mut($crate::CastAsAny::cast_as_any_mut(self))
             }
         }
     };

--- a/crates/brace-cast/src/registry.rs
+++ b/crates/brace-cast/src/registry.rs
@@ -1,0 +1,126 @@
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+use inventory::collect;
+use lazy_static::lazy_static;
+
+use crate::Cast;
+
+lazy_static! {
+    static ref CAST_REF_REGISTRY: CastRefRegistry = CastRefRegistry::new();
+    static ref CAST_MUT_REGISTRY: CastMutRegistry = CastMutRegistry::new();
+}
+
+collect!(CastRefRecord);
+collect!(CastMutRecord);
+
+pub type CastRefHandler<T> = fn(&dyn Any) -> Option<&T>;
+pub type CastMutHandler<T> = fn(&mut dyn Any) -> Option<&mut T>;
+
+pub fn cast_from_ref<S, T>(from: &S) -> Option<&T>
+where
+    S: Cast + ?Sized + 'static,
+    T: ?Sized + 'static,
+{
+    CAST_REF_REGISTRY.cast_from_ref(from)
+}
+
+pub fn cast_from_mut<S, T>(from: &mut S) -> Option<&mut T>
+where
+    S: Cast + ?Sized + 'static,
+    T: ?Sized + 'static,
+{
+    CAST_MUT_REGISTRY.cast_from_mut(from)
+}
+
+pub struct CastRefRecord(TypeId, TypeId, Box<dyn Any + Sync>);
+
+impl CastRefRecord {
+    pub fn new<S, T>(handler: CastRefHandler<T>) -> Self
+    where
+        S: 'static,
+        T: ?Sized + 'static,
+    {
+        Self(TypeId::of::<T>(), TypeId::of::<S>(), Box::new(handler))
+    }
+}
+
+pub struct CastMutRecord(TypeId, TypeId, Box<dyn Any + Sync>);
+
+impl CastMutRecord {
+    pub fn new<S, T>(handler: CastMutHandler<T>) -> Self
+    where
+        S: 'static,
+        T: ?Sized + 'static,
+    {
+        Self(TypeId::of::<T>(), TypeId::of::<S>(), Box::new(handler))
+    }
+}
+
+#[derive(Default)]
+pub struct CastRefRegistry(HashMap<(TypeId, TypeId), &'static CastRefRecord>);
+
+impl CastRefRegistry {
+    pub fn new() -> Self {
+        let mut map = HashMap::new();
+
+        for rec in inventory::iter::<CastRefRecord> {
+            map.insert((rec.0, rec.1), rec);
+        }
+
+        Self(map)
+    }
+
+    pub fn cast_from_ref<'a, S, T>(&self, from: &'a S) -> Option<&'a T>
+    where
+        S: Cast + ?Sized + 'static,
+        T: ?Sized + 'static,
+    {
+        let from = from.cast_as_any_ref();
+        let type_id = from.type_id();
+
+        if let Some(rec) = self.0.get(&(TypeId::of::<T>(), type_id)) {
+            let item = (&*rec.2) as &dyn Any;
+
+            if let Some(cast) = item.downcast_ref::<CastRefHandler<T>>() {
+                return (cast)(from);
+            }
+        }
+
+        None
+    }
+}
+
+#[derive(Default)]
+pub struct CastMutRegistry(HashMap<(TypeId, TypeId), &'static CastMutRecord>);
+
+impl CastMutRegistry {
+    pub fn new() -> Self {
+        let mut map = HashMap::new();
+
+        for rec in inventory::iter::<CastMutRecord> {
+            map.insert((rec.0, rec.1), rec);
+        }
+
+        Self(map)
+    }
+
+    pub fn cast_from_mut<'a, S, T>(&self, from: &'a mut S) -> Option<&'a mut T>
+    where
+        S: Cast + ?Sized + 'static,
+        T: ?Sized + 'static,
+    {
+        let from = (*from).cast_as_any_mut();
+        let type_id = (from as &dyn Any).type_id();
+
+        if let Some(rec) = self.0.get(&(TypeId::of::<T>(), type_id)) {
+            let item = (&*rec.2) as &dyn Any;
+
+            if let Some(cast) = item.downcast_ref::<CastMutHandler<T>>() {
+                return (cast)(from);
+            }
+        }
+
+        None
+    }
+}


### PR DESCRIPTION
This adds macros that simplify the use of the library by generating cast implementations.