### PR TITLE
Use cast from trait macro in tests

### DIFF
--- a/crates/brace-cast/src/lib.rs
+++ b/crates/brace-cast/src/lib.rs
@@ -200,6 +200,9 @@ mod tests {
         }
     }
 
+    impl_cast_as!(struct Cat: Animal, Feline);
+    impl_cast_as!(trait Animal: Feline);
+
     struct Dog {
         name: String,
         ears: usize,
@@ -230,8 +233,7 @@ mod tests {
     }
 
     impl_cast_from!(struct Dog: Animal, Canine);
-    impl_cast_as!(struct Cat: Animal, Feline);
-    impl_cast_as!(trait Animal: Feline, Canine);
+    impl_cast_from!(trait Animal: Canine);
 
     #[test]
     fn test_cast_struct_as_trait_object() {


### PR DESCRIPTION
This updates the tests to cover the _impl_cast_from_ macro.