### PR TITLE
Add attribute macro for tagged impl and trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
   "crates/brace-cast",
+  "crates/brace-cast-macros",
 ]

--- a/crates/brace-cast-macros/Cargo.toml
+++ b/crates/brace-cast-macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "brace-cast-macros"
+version = "0.1.0"
+authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
+description = "Provides procedural macros for casting between trait objects."
+repository = "https://github.com/brace-rs/brace-cast"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["full"] }

--- a/crates/brace-cast-macros/src/lib.rs
+++ b/crates/brace-cast-macros/src/lib.rs
@@ -1,0 +1,20 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use syn::parse_macro_input;
+
+use crate::parse::Input;
+
+mod parse;
+mod tagged_impl;
+mod tagged_trait;
+
+#[proc_macro_attribute]
+pub fn cast(_: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as Input);
+
+    TokenStream::from(match input {
+        Input::Impl(input) => tagged_impl::expand(input),
+        Input::Trait(input) => tagged_trait::expand(input),
+    })
+}

--- a/crates/brace-cast-macros/src/parse.rs
+++ b/crates/brace-cast-macros/src/parse.rs
@@ -1,0 +1,47 @@
+use quote::quote;
+use syn::parse::{Parse, ParseStream, Result};
+use syn::{Attribute, Error, ItemImpl, ItemTrait, Token, Visibility};
+
+pub enum Input {
+    Trait(ItemTrait),
+    Impl(ItemImpl),
+}
+
+impl Parse for Input {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut attrs = Attribute::parse_outer(input)?;
+        let ahead = input.fork();
+
+        ahead.parse::<Visibility>()?;
+        ahead.parse::<Option<Token![unsafe]>>()?;
+
+        if ahead.peek(Token![trait]) {
+            let mut item: ItemTrait = input.parse()?;
+
+            attrs.extend(item.attrs);
+            item.attrs = attrs;
+
+            return Ok(Input::Trait(item));
+        }
+
+        if ahead.peek(Token![impl]) {
+            let mut item: ItemImpl = input.parse()?;
+
+            if item.trait_.is_none() {
+                let impl_token = item.impl_token;
+                let ty = item.self_ty;
+                let span = quote!(#impl_token #ty);
+                let msg = "expected impl Trait for Type";
+
+                return Err(Error::new_spanned(span, msg));
+            }
+
+            attrs.extend(item.attrs);
+            item.attrs = attrs;
+
+            return Ok(Input::Impl(item));
+        }
+
+        Err(input.error("expected trait Trait or impl Trait for Type"))
+    }
+}

--- a/crates/brace-cast-macros/src/tagged_impl.rs
+++ b/crates/brace-cast-macros/src/tagged_impl.rs
@@ -1,0 +1,13 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::ItemImpl;
+
+pub fn expand(input: ItemImpl) -> TokenStream {
+    let from = &input.self_ty;
+    let into = &input.trait_.as_ref().unwrap().1;
+
+    quote! {
+        #input
+        brace_cast::impl_cast_as!(struct #from : #into);
+    }
+}

--- a/crates/brace-cast-macros/src/tagged_trait.rs
+++ b/crates/brace-cast-macros/src/tagged_trait.rs
@@ -1,0 +1,25 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_quote, ItemTrait, TypeParamBound};
+
+pub fn expand(mut input: ItemTrait) -> TokenStream {
+    let mut output = TokenStream::new();
+    let from = &input.ident;
+
+    for supertrait in &input.supertraits {
+        if let TypeParamBound::Trait(trait_bound) = supertrait {
+            let into = &trait_bound.path;
+
+            output.extend(quote! {
+                brace_cast::impl_cast_as!(trait #from : #into);
+            });
+        }
+    }
+
+    input.supertraits.push(parse_quote!(brace_cast::Cast));
+
+    quote! {
+        #input
+        #output
+    }
+}

--- a/crates/brace-cast/Cargo.toml
+++ b/crates/brace-cast/Cargo.toml
@@ -8,5 +8,6 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+brace-cast-macros = { path = "../brace-cast-macros" }
 inventory = "0.1"
 lazy_static = "1.4"

--- a/crates/brace-cast/src/lib.rs
+++ b/crates/brace-cast/src/lib.rs
@@ -175,6 +175,10 @@ mod tests {
         fn ears(&self) -> &usize;
     }
 
+    trait Rodent: Mammal {
+        fn tail(&self) -> &bool;
+    }
+
     struct Cat {
         name: String,
         legs: usize,
@@ -257,6 +261,47 @@ mod tests {
     impl_cast_from!(trait Animal: Canine);
     impl_cast_from!(trait Mammal: Canine);
 
+    struct Rat {
+        name: String,
+        legs: usize,
+        tail: bool,
+    }
+
+    impl Rat {
+        fn new<S>(name: S) -> Self
+        where
+            S: Into<String>,
+        {
+            Self {
+                name: name.into(),
+                legs: 4,
+                tail: true,
+            }
+        }
+    }
+
+    impl Animal for Rat {
+        fn name(&self) -> &str {
+            &self.name
+        }
+    }
+
+    impl Mammal for Rat {
+        fn legs(&self) -> &usize {
+            &self.legs
+        }
+    }
+
+    impl Rodent for Rat {
+        fn tail(&self) -> &bool {
+            &self.tail
+        }
+    }
+
+    impl_cast_from!(struct Rat: Animal, Mammal, Rodent);
+    impl_cast_from!(trait Animal: Rodent);
+    impl_cast_from!(trait Mammal: Rodent);
+
     #[test]
     fn test_cast_struct_as_trait_object() {
         let mut cat = Cat::new("Felix");
@@ -276,6 +321,15 @@ mod tests {
         assert!(dog.cast_mut::<dyn Animal>().is_some());
         assert!(dog.cast_mut::<dyn Mammal>().is_some());
         assert!(dog.cast_mut::<dyn Canine>().is_some());
+
+        let mut rat = Rat::new("Daisy");
+
+        assert!(rat.cast_ref::<dyn Animal>().is_some());
+        assert!(rat.cast_ref::<dyn Mammal>().is_some());
+        assert!(rat.cast_ref::<dyn Rodent>().is_some());
+        assert!(rat.cast_mut::<dyn Animal>().is_some());
+        assert!(rat.cast_mut::<dyn Mammal>().is_some());
+        assert!(rat.cast_mut::<dyn Rodent>().is_some());
     }
 
     #[test]
@@ -284,15 +338,19 @@ mod tests {
 
         assert!(cat.cast_ref::<Cat>().is_some());
         assert!(cat.cast_ref::<Dog>().is_none());
+        assert!(cat.cast_ref::<Rat>().is_none());
         assert!(cat.cast_mut::<Cat>().is_some());
         assert!(cat.cast_mut::<Dog>().is_none());
+        assert!(cat.cast_mut::<Rat>().is_none());
 
         let mut cat: Box<dyn Mammal> = Box::new(Cat::new("Felix"));
 
         assert!(cat.cast_ref::<Cat>().is_some());
         assert!(cat.cast_ref::<Dog>().is_none());
+        assert!(cat.cast_ref::<Rat>().is_none());
         assert!(cat.cast_mut::<Cat>().is_some());
         assert!(cat.cast_mut::<Dog>().is_none());
+        assert!(cat.cast_mut::<Rat>().is_none());
 
         let mut cat: Box<dyn Feline> = Box::new(Cat::new("Felix"));
 
@@ -303,20 +361,47 @@ mod tests {
 
         assert!(dog.cast_ref::<Cat>().is_none());
         assert!(dog.cast_ref::<Dog>().is_some());
+        assert!(dog.cast_ref::<Rat>().is_none());
         assert!(dog.cast_mut::<Cat>().is_none());
         assert!(dog.cast_mut::<Dog>().is_some());
+        assert!(dog.cast_mut::<Rat>().is_none());
 
         let mut dog: Box<dyn Mammal> = Box::new(Dog::new("Rover"));
 
         assert!(dog.cast_ref::<Cat>().is_none());
         assert!(dog.cast_ref::<Dog>().is_some());
+        assert!(dog.cast_ref::<Rat>().is_none());
         assert!(dog.cast_mut::<Cat>().is_none());
         assert!(dog.cast_mut::<Dog>().is_some());
+        assert!(dog.cast_mut::<Rat>().is_none());
 
         let mut dog: Box<dyn Canine> = Box::new(Dog::new("Rover"));
 
         assert!(dog.cast_ref::<Dog>().is_some());
         assert!(dog.cast_mut::<Dog>().is_some());
+
+        let mut rat: Box<dyn Animal> = Box::new(Rat::new("Daisy"));
+
+        assert!(rat.cast_ref::<Cat>().is_none());
+        assert!(rat.cast_ref::<Dog>().is_none());
+        assert!(rat.cast_ref::<Rat>().is_some());
+        assert!(rat.cast_mut::<Cat>().is_none());
+        assert!(rat.cast_mut::<Dog>().is_none());
+        assert!(rat.cast_mut::<Rat>().is_some());
+
+        let mut rat: Box<dyn Mammal> = Box::new(Rat::new("Daisy"));
+
+        assert!(rat.cast_ref::<Cat>().is_none());
+        assert!(rat.cast_ref::<Dog>().is_none());
+        assert!(rat.cast_ref::<Rat>().is_some());
+        assert!(rat.cast_mut::<Cat>().is_none());
+        assert!(rat.cast_mut::<Dog>().is_none());
+        assert!(rat.cast_mut::<Rat>().is_some());
+
+        let mut rat: Box<dyn Rodent> = Box::new(Rat::new("Daisy"));
+
+        assert!(rat.cast_ref::<Rat>().is_some());
+        assert!(rat.cast_mut::<Rat>().is_some());
     }
 
     #[test]
@@ -326,16 +411,20 @@ mod tests {
 
         assert!(cast_ref::<Cat, _>(cat).is_some());
         assert!(cast_ref::<Dog, _>(cat).is_none());
+        assert!(cast_ref::<Rat, _>(cat).is_none());
         assert!(cast_mut::<Cat, _>(cat).is_some());
         assert!(cast_mut::<Dog, _>(cat).is_none());
+        assert!(cast_mut::<Rat, _>(cat).is_none());
 
         let mut cat: Box<dyn Mammal> = Box::new(Cat::new("Felix"));
         let cat: &mut dyn Mammal = &mut *cat;
 
         assert!(cast_ref::<Cat, _>(cat).is_some());
         assert!(cast_ref::<Dog, _>(cat).is_none());
+        assert!(cast_ref::<Rat, _>(cat).is_none());
         assert!(cast_mut::<Cat, _>(cat).is_some());
         assert!(cast_mut::<Dog, _>(cat).is_none());
+        assert!(cast_mut::<Rat, _>(cat).is_none());
 
         let mut cat: Box<dyn Feline> = Box::new(Cat::new("Felix"));
         let cat: &mut dyn Feline = &mut *cat;
@@ -348,22 +437,52 @@ mod tests {
 
         assert!(cast_ref::<Cat, _>(dog).is_none());
         assert!(cast_ref::<Dog, _>(dog).is_some());
+        assert!(cast_ref::<Rat, _>(dog).is_none());
         assert!(cast_mut::<Cat, _>(dog).is_none());
         assert!(cast_mut::<Dog, _>(dog).is_some());
+        assert!(cast_mut::<Rat, _>(dog).is_none());
 
         let mut dog: Box<dyn Mammal> = Box::new(Dog::new("Rover"));
         let dog: &mut dyn Mammal = &mut *dog;
 
         assert!(cast_ref::<Cat, _>(dog).is_none());
         assert!(cast_ref::<Dog, _>(dog).is_some());
+        assert!(cast_ref::<Rat, _>(dog).is_none());
         assert!(cast_mut::<Cat, _>(dog).is_none());
         assert!(cast_mut::<Dog, _>(dog).is_some());
+        assert!(cast_mut::<Rat, _>(dog).is_none());
 
         let mut dog: Box<dyn Canine> = Box::new(Dog::new("Rover"));
         let dog: &mut dyn Canine = &mut *dog;
 
         assert!(cast_ref::<Dog, _>(dog).is_some());
         assert!(cast_mut::<Dog, _>(dog).is_some());
+
+        let mut rat: Box<dyn Animal> = Box::new(Rat::new("Daisy"));
+        let rat: &mut dyn Animal = &mut *rat;
+
+        assert!(cast_ref::<Cat, _>(rat).is_none());
+        assert!(cast_ref::<Dog, _>(rat).is_none());
+        assert!(cast_ref::<Rat, _>(rat).is_some());
+        assert!(cast_mut::<Cat, _>(rat).is_none());
+        assert!(cast_mut::<Dog, _>(rat).is_none());
+        assert!(cast_mut::<Rat, _>(rat).is_some());
+
+        let mut rat: Box<dyn Mammal> = Box::new(Rat::new("Daisy"));
+        let rat: &mut dyn Mammal = &mut *rat;
+
+        assert!(cast_ref::<Cat, _>(rat).is_none());
+        assert!(cast_ref::<Dog, _>(rat).is_none());
+        assert!(cast_ref::<Rat, _>(rat).is_some());
+        assert!(cast_mut::<Cat, _>(rat).is_none());
+        assert!(cast_mut::<Dog, _>(rat).is_none());
+        assert!(cast_mut::<Rat, _>(rat).is_some());
+
+        let mut rat: Box<dyn Rodent> = Box::new(Rat::new("Daisy"));
+        let rat: &mut dyn Rodent = &mut *rat;
+
+        assert!(cast_ref::<Rat, _>(rat).is_some());
+        assert!(cast_mut::<Rat, _>(rat).is_some());
     }
 
     #[test]
@@ -373,18 +492,22 @@ mod tests {
         assert!(cat.cast_ref::<dyn Mammal>().is_some());
         assert!(cat.cast_ref::<dyn Feline>().is_some());
         assert!(cat.cast_ref::<dyn Canine>().is_none());
+        assert!(cat.cast_ref::<dyn Rodent>().is_none());
         assert!(cat.cast_mut::<dyn Mammal>().is_some());
         assert!(cat.cast_mut::<dyn Feline>().is_some());
         assert!(cat.cast_mut::<dyn Canine>().is_none());
+        assert!(cat.cast_mut::<dyn Rodent>().is_none());
 
         let mut cat: Box<dyn Mammal> = Box::new(Cat::new("Felix"));
 
         assert!(cat.cast_ref::<dyn Animal>().is_some());
         assert!(cat.cast_ref::<dyn Feline>().is_some());
         assert!(cat.cast_ref::<dyn Canine>().is_none());
+        assert!(cat.cast_ref::<dyn Rodent>().is_none());
         assert!(cat.cast_mut::<dyn Animal>().is_some());
         assert!(cat.cast_mut::<dyn Feline>().is_some());
         assert!(cat.cast_mut::<dyn Canine>().is_none());
+        assert!(cat.cast_mut::<dyn Rodent>().is_none());
 
         let mut cat: Box<dyn Feline> = Box::new(Cat::new("Felix"));
 
@@ -398,18 +521,22 @@ mod tests {
         assert!(dog.cast_ref::<dyn Mammal>().is_some());
         assert!(dog.cast_ref::<dyn Feline>().is_none());
         assert!(dog.cast_ref::<dyn Canine>().is_some());
+        assert!(dog.cast_ref::<dyn Rodent>().is_none());
         assert!(dog.cast_mut::<dyn Mammal>().is_some());
         assert!(dog.cast_mut::<dyn Feline>().is_none());
         assert!(dog.cast_mut::<dyn Canine>().is_some());
+        assert!(dog.cast_mut::<dyn Rodent>().is_none());
 
         let mut dog: Box<dyn Mammal> = Box::new(Dog::new("Rover"));
 
         assert!(dog.cast_ref::<dyn Animal>().is_some());
         assert!(dog.cast_ref::<dyn Feline>().is_none());
         assert!(dog.cast_ref::<dyn Canine>().is_some());
+        assert!(dog.cast_ref::<dyn Rodent>().is_none());
         assert!(dog.cast_mut::<dyn Animal>().is_some());
         assert!(dog.cast_mut::<dyn Feline>().is_none());
         assert!(dog.cast_mut::<dyn Canine>().is_some());
+        assert!(dog.cast_mut::<dyn Rodent>().is_none());
 
         let mut dog: Box<dyn Canine> = Box::new(Dog::new("Rover"));
 
@@ -417,6 +544,35 @@ mod tests {
         assert!(dog.cast_ref::<dyn Mammal>().is_some());
         assert!(dog.cast_mut::<dyn Animal>().is_some());
         assert!(dog.cast_mut::<dyn Mammal>().is_some());
+
+        let mut rat: Box<dyn Animal> = Box::new(Rat::new("Daisy"));
+
+        assert!(rat.cast_ref::<dyn Mammal>().is_some());
+        assert!(rat.cast_ref::<dyn Feline>().is_none());
+        assert!(rat.cast_ref::<dyn Canine>().is_none());
+        assert!(rat.cast_ref::<dyn Rodent>().is_some());
+        assert!(rat.cast_mut::<dyn Mammal>().is_some());
+        assert!(rat.cast_mut::<dyn Feline>().is_none());
+        assert!(rat.cast_mut::<dyn Canine>().is_none());
+        assert!(rat.cast_mut::<dyn Rodent>().is_some());
+
+        let mut rat: Box<dyn Mammal> = Box::new(Rat::new("Daisy"));
+
+        assert!(rat.cast_ref::<dyn Animal>().is_some());
+        assert!(rat.cast_ref::<dyn Feline>().is_none());
+        assert!(rat.cast_ref::<dyn Canine>().is_none());
+        assert!(rat.cast_ref::<dyn Rodent>().is_some());
+        assert!(rat.cast_mut::<dyn Animal>().is_some());
+        assert!(rat.cast_mut::<dyn Feline>().is_none());
+        assert!(rat.cast_mut::<dyn Canine>().is_none());
+        assert!(rat.cast_mut::<dyn Rodent>().is_some());
+
+        let mut rat: Box<dyn Rodent> = Box::new(Rat::new("Daisy"));
+
+        assert!(rat.cast_ref::<dyn Animal>().is_some());
+        assert!(rat.cast_ref::<dyn Mammal>().is_some());
+        assert!(rat.cast_mut::<dyn Animal>().is_some());
+        assert!(rat.cast_mut::<dyn Mammal>().is_some());
     }
 
     #[test]
@@ -427,9 +583,11 @@ mod tests {
         assert!(cast_ref::<dyn Mammal, _>(cat).is_some());
         assert!(cast_ref::<dyn Feline, _>(cat).is_some());
         assert!(cast_ref::<dyn Canine, _>(cat).is_none());
+        assert!(cast_ref::<dyn Rodent, _>(cat).is_none());
         assert!(cast_mut::<dyn Mammal, _>(cat).is_some());
         assert!(cast_mut::<dyn Feline, _>(cat).is_some());
         assert!(cast_mut::<dyn Canine, _>(cat).is_none());
+        assert!(cast_mut::<dyn Rodent, _>(cat).is_none());
 
         let mut cat: Box<dyn Mammal> = Box::new(Cat::new("Felix"));
         let cat: &mut dyn Mammal = &mut *cat;
@@ -437,9 +595,11 @@ mod tests {
         assert!(cast_ref::<dyn Animal, _>(cat).is_some());
         assert!(cast_ref::<dyn Feline, _>(cat).is_some());
         assert!(cast_ref::<dyn Canine, _>(cat).is_none());
+        assert!(cast_ref::<dyn Rodent, _>(cat).is_none());
         assert!(cast_mut::<dyn Animal, _>(cat).is_some());
         assert!(cast_mut::<dyn Feline, _>(cat).is_some());
         assert!(cast_mut::<dyn Canine, _>(cat).is_none());
+        assert!(cast_mut::<dyn Rodent, _>(cat).is_none());
 
         let mut cat: Box<dyn Feline> = Box::new(Cat::new("Felix"));
         let cat: &mut dyn Feline = &mut *cat;
@@ -455,9 +615,11 @@ mod tests {
         assert!(cast_ref::<dyn Mammal, _>(dog).is_some());
         assert!(cast_ref::<dyn Feline, _>(dog).is_none());
         assert!(cast_ref::<dyn Canine, _>(dog).is_some());
+        assert!(cast_ref::<dyn Rodent, _>(dog).is_none());
         assert!(cast_mut::<dyn Mammal, _>(dog).is_some());
         assert!(cast_mut::<dyn Feline, _>(dog).is_none());
         assert!(cast_mut::<dyn Canine, _>(dog).is_some());
+        assert!(cast_mut::<dyn Rodent, _>(dog).is_none());
 
         let mut dog: Box<dyn Mammal> = Box::new(Dog::new("Rover"));
         let dog: &mut dyn Mammal = &mut *dog;
@@ -465,9 +627,11 @@ mod tests {
         assert!(cast_ref::<dyn Animal, _>(dog).is_some());
         assert!(cast_ref::<dyn Feline, _>(dog).is_none());
         assert!(cast_ref::<dyn Canine, _>(dog).is_some());
+        assert!(cast_ref::<dyn Rodent, _>(dog).is_none());
         assert!(cast_mut::<dyn Animal, _>(dog).is_some());
         assert!(cast_mut::<dyn Feline, _>(dog).is_none());
         assert!(cast_mut::<dyn Canine, _>(dog).is_some());
+        assert!(cast_mut::<dyn Rodent, _>(dog).is_none());
 
         let mut dog: Box<dyn Canine> = Box::new(Dog::new("Rover"));
         let dog: &mut dyn Canine = &mut *dog;
@@ -476,5 +640,37 @@ mod tests {
         assert!(cast_ref::<dyn Mammal, _>(dog).is_some());
         assert!(cast_mut::<dyn Animal, _>(dog).is_some());
         assert!(cast_mut::<dyn Mammal, _>(dog).is_some());
+
+        let mut rat: Box<dyn Animal> = Box::new(Rat::new("Daisy"));
+        let rat: &mut dyn Animal = &mut *rat;
+
+        assert!(cast_ref::<dyn Mammal, _>(rat).is_some());
+        assert!(cast_ref::<dyn Feline, _>(rat).is_none());
+        assert!(cast_ref::<dyn Canine, _>(rat).is_none());
+        assert!(cast_ref::<dyn Rodent, _>(rat).is_some());
+        assert!(cast_mut::<dyn Mammal, _>(rat).is_some());
+        assert!(cast_mut::<dyn Feline, _>(rat).is_none());
+        assert!(cast_mut::<dyn Canine, _>(rat).is_none());
+        assert!(cast_mut::<dyn Rodent, _>(rat).is_some());
+
+        let mut rat: Box<dyn Mammal> = Box::new(Rat::new("Daisy"));
+        let rat: &mut dyn Mammal = &mut *rat;
+
+        assert!(cast_ref::<dyn Animal, _>(rat).is_some());
+        assert!(cast_ref::<dyn Feline, _>(rat).is_none());
+        assert!(cast_ref::<dyn Canine, _>(rat).is_none());
+        assert!(cast_ref::<dyn Rodent, _>(rat).is_some());
+        assert!(cast_mut::<dyn Animal, _>(rat).is_some());
+        assert!(cast_mut::<dyn Feline, _>(rat).is_none());
+        assert!(cast_mut::<dyn Canine, _>(rat).is_none());
+        assert!(cast_mut::<dyn Rodent, _>(rat).is_some());
+
+        let mut rat: Box<dyn Rodent> = Box::new(Rat::new("Daisy"));
+        let rat: &mut dyn Rodent = &mut *rat;
+
+        assert!(cast_ref::<dyn Animal, _>(rat).is_some());
+        assert!(cast_ref::<dyn Mammal, _>(rat).is_some());
+        assert!(cast_mut::<dyn Animal, _>(rat).is_some());
+        assert!(cast_mut::<dyn Mammal, _>(rat).is_some());
     }
 }

--- a/crates/brace-cast/src/lib.rs
+++ b/crates/brace-cast/src/lib.rs
@@ -1,7 +1,10 @@
+extern crate self as brace_cast;
+
 use std::any::Any;
 use std::rc::Rc;
 use std::sync::Arc;
 
+pub use brace_cast_macros::cast;
 pub use inventory;
 
 pub mod macros;
@@ -157,7 +160,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{cast_mut, cast_ref, impl_cast_as, impl_cast_from, Cast};
+    use crate::{cast, cast_mut, cast_ref, impl_cast_as, impl_cast_from, Cast};
 
     trait Animal: Cast {
         fn name(&self) -> &str;
@@ -175,7 +178,8 @@ mod tests {
         fn ears(&self) -> &usize;
     }
 
-    trait Rodent: Mammal {
+    #[cast]
+    trait Rodent: Animal + Mammal {
         fn tail(&self) -> &bool;
     }
 
@@ -280,27 +284,26 @@ mod tests {
         }
     }
 
+    #[cast]
     impl Animal for Rat {
         fn name(&self) -> &str {
             &self.name
         }
     }
 
+    #[cast]
     impl Mammal for Rat {
         fn legs(&self) -> &usize {
             &self.legs
         }
     }
 
+    #[cast]
     impl Rodent for Rat {
         fn tail(&self) -> &bool {
             &self.tail
         }
     }
-
-    impl_cast_from!(struct Rat: Animal, Mammal, Rodent);
-    impl_cast_from!(trait Animal: Rodent);
-    impl_cast_from!(trait Mammal: Rodent);
 
     #[test]
     fn test_cast_struct_as_trait_object() {


### PR DESCRIPTION
This adds an attribute macro to provide automatic casting implementations for tagged impl and trait blocks.